### PR TITLE
AOS-654 V2 네이밍 제거

### DIFF
--- a/src/main/resources/templates/ActivityTemplate.txt
+++ b/src/main/resources/templates/ActivityTemplate.txt
@@ -3,7 +3,7 @@ package $PACKAGE$
 import androidx.lifecycle.LifecycleOwner
 import kr.co.finda.finda.R
 import kr.co.finda.finda.databinding.Activity$NAME$Binding
-import kr.co.finda.finda.ui.base.v2.BaseActivityV2
+import kr.co.finda.finda.ui.base.BaseActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 

--- a/src/main/resources/templates/FragmentTemplate.txt
+++ b/src/main/resources/templates/FragmentTemplate.txt
@@ -3,25 +3,24 @@ package $PACKAGE$
 import androidx.lifecycle.LifecycleOwner
 import kr.co.finda.finda.R
 import kr.co.finda.finda.databinding.Fragment$NAME$Binding
-import kr.co.finda.finda.ui.base.v2.BaseFragmentV2
+import kr.co.finda.finda.ui.base.BaseFragment
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
-class $NAME$Fragment : BaseFragment<Fragment$NAME$Binding>(
+class $NAME$Fragment : BaseFragment<Fragment$NAME$Binding, $NAME$ViewModel>(
     R.layout.$LAYOUT_NAME$
 ) {
+    override val viewModel: $NAME$ViewModel by sharedViewModel()
 
-     override val viewModel: $NAME$ViewModel by sharedViewModel()
+    override fun onInitialize(lifecycleOwner: LifecycleOwner) {
+        super.onInitialize(lifecycleOwner)
+        binding.viewModel = viewModel
+    }
 
-        override fun onInitialize(lifecycleOwner: LifecycleOwner) {
-            super.onInitialize(lifecycleOwner)
-            binding.viewModel = viewModel
-        }
+    override fun setupUiComponent() {
 
-        override fun setupUiComponent() {
+    }
 
-        }
+    override fun observeLiveData() {
 
-        override fun observeLiveData() {
-
-        }
+    }
 }

--- a/src/main/resources/templates/ViewModelTemplate.txt
+++ b/src/main/resources/templates/ViewModelTemplate.txt
@@ -1,8 +1,8 @@
 package $PACKAGE$
 
-import kr.co.finda.finda.ui.base.v2.BaseViewModelV2
+import kr.co.finda.finda.ui.base.BaseViewModel
 
-class $NAME$ViewModel : BaseViewModelV2() {
+class $NAME$ViewModel : BaseViewModel() {
 
 
 }


### PR DESCRIPTION
BaseUIV2 내용들이 적용되면서 기존에 있던 'V2' 네이밍들이 제거되어 플러그인 이용해 생성하는 경우 오류가 발생합니다.
이 부분 해결하기 위해 Template 내용들을 수정했습니다. 